### PR TITLE
Converted namespace from IKL_ to sns_ikl

### DIFF
--- a/include/sns_ikl/sns_ikl.hpp
+++ b/include/sns_ikl/sns_ikl.hpp
@@ -1,4 +1,4 @@
-/*! \file IKL.hpp
+/*! \file sns_ikl.hpp
  * \brief The SNS Inverse Kinematic Library (\b IKL)
  * \author Fabrizio Flacco
  */
@@ -17,8 +17,8 @@
  *    limitations under the License.
  */
 
-#ifndef _IKL_
-#define _IKL_
+#ifndef SNS_IKL
+#define SNS_IKL
 
 #include <Eigen/Dense>
 #include <vector>
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace Eigen;
 
-namespace IKL_ {
+namespace sns_ikl {
 
 #define _USE_DOUBLE_  
 /*! \def _USE_DOUBLE_  

--- a/src/sns_ikl.cpp
+++ b/src/sns_ikl.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 using namespace Eigen;
-using namespace IKL_;
+using namespace sns_ikl;
 
 IKL::IKL(inv_solvers solver) {
   initializeMap();

--- a/src/test_ikl.cpp
+++ b/src/test_ikl.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 using namespace Eigen;
-using namespace IKL_;
+using namespace sns_ikl;
 
 int main(int argc, char** argv) {
   


### PR DESCRIPTION
According to ROS Cpp style guide, the namespaces of
the libraries should be underscored:
http://wiki.ros.org/CppStyleGuide#Namespaces

This change converts the namespace to be in line
with the style guide: IKL_ to sns_ikl