### PR TITLE
Adds the ability to set velocity solver in SNS_IK

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -27,10 +27,11 @@
 #include <kdl/chainfksolverpos_recursive.hpp>
 
 #include "sns_ik/sns_ik_math_utils.hpp"
-#include "sns_ik/sns_velocity_ik.hpp"
 
 namespace sns_ik {
 
+// Forward declare SNS Velocity Base Class
+class SNSVelocityIK;
 class SNSPositionIK {
   public:
     SNSPositionIK(KDL::Chain chain, std::shared_ptr<SNSVelocityIK> velocity_ik);

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -18,7 +18,7 @@
  */
 
 #include <sns_ik/sns_position_ik.hpp>
-
+#include <sns_ik/sns_velocity_ik.hpp>
 #include <iostream>
 
 namespace sns_ik{


### PR DESCRIPTION
Prior to this commit, one one need to set the velocity solver manually.
This introduces the public setVelocitySolveType() function for creating
and changing velocity solvers from the SNS_IK class' public interface.

I also created some forward declarations to prevent unnecessary linking
of velocity solver headers that aren't being used in the client's code.