### PR TITLE
Adds close delta seeds for Position IK Testing

### DIFF
--- a/sns_ik_examples/launch/test_ik_solvers.launch
+++ b/sns_ik_examples/launch/test_ik_solvers.launch
@@ -8,7 +8,8 @@
   <arg name="urdf_param" default="/robot_description" />
   <arg name="load_robot_description" default="true"/>
   <arg name="random_position_seed" default="false"/>
-  <arg name="close_position_seed" default="false"/>
+  <arg name="close_position_seed" default="true"/>
+  <arg name="position_seed_delta" default="0.2"/>
 
   <param if="$(arg load_robot_description)" name="$(arg urdf_param)"
     command="cat $(find baxter_description)/urdf/baxter.urdf"/>
@@ -24,6 +25,7 @@
     <param name="urdf_param" value="$(arg urdf_param)"/>
     <param name="random_position_seed" value="$(arg random_position_seed)"/>
     <param name="close_position_seed" value="$(arg close_position_seed)"/>
+    <param name="position_seed_delta" value="$(arg position_seed_delta)"/>
   </node>
 
 </launch>

--- a/sns_ik_examples/launch/test_ik_solvers.launch
+++ b/sns_ik_examples/launch/test_ik_solvers.launch
@@ -8,6 +8,7 @@
   <arg name="urdf_param" default="/robot_description" />
   <arg name="load_robot_description" default="true"/>
   <arg name="random_position_seed" default="false"/>
+  <arg name="close_position_seed" default="false"/>
 
   <param if="$(arg load_robot_description)" name="$(arg urdf_param)"
     command="cat $(find baxter_description)/urdf/baxter.urdf"/>
@@ -22,6 +23,7 @@
     <param name="timeout" value="$(arg timeout)"/>
     <param name="urdf_param" value="$(arg urdf_param)"/>
     <param name="random_position_seed" value="$(arg random_position_seed)"/>
+    <param name="close_position_seed" value="$(arg close_position_seed)"/>
   </node>
 
 </launch>

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -44,6 +44,25 @@ double fRand(double min, double max)
   return min + f * (max - min);
 }
 
+double getDeltaWithLimits(double value, double desired_delta,
+                          double limit_min, double limit_max)
+{
+  double valid_delta;
+  double lower_delta = value-desired_delta;
+  double upper_delta = value+desired_delta;
+  double upper_side = (double)rand() / RAND_MAX >= 0.5;
+  if( upper_side && upper_delta > limit_max ){
+      valid_delta = lower_delta;
+  } else if( upper_side && upper_delta <= limit_max) {
+      valid_delta = upper_delta;
+  } else if( !upper_side && lower_delta < limit_min ){
+      valid_delta = upper_delta;
+  } else if( !upper_side && lower_delta >= limit_min ){
+      valid_delta = lower_delta;
+  }
+  return valid_delta;
+}
+
 bool in_vel_bounds(KDL::JntArray vals, KDL::JntArray vels)
 {
   for(size_t i; i < vels.data.size(); i++){
@@ -100,11 +119,10 @@ bool velocityIsScaled(KDL::FrameVel fv1, KDL::FrameVel fv2, double eps, double *
 
 void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
           std::string chain_start, std::string chain_end, double timeout,
-          std::string urdf_param, bool randomPositionSeed)
+          std::string urdf_param, bool randomPositionSeed, bool closePositionSeed)
 {
 
   double eps = 1e-5;
-
   // This constructor parses the URDF loaded in rosparm urdf_param into the
   // needed KDL structures.  We then pull these out to compare against the KDL
   // IK solver.
@@ -149,14 +167,18 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
 
   // Create desired number of valid, random joint configurations
   std::vector<KDL::JntArray> JointList;
+  std::vector<KDL::JntArray> JointDeltaSeed;
   KDL::JntArray q(chain.getNrOfJoints());
+  KDL::JntArray q_delta(chain.getNrOfJoints());
 
   uint num_joint_pos = std::max(num_samples_pos, num_samples_vel);
   for (uint i=0; i < num_joint_pos; i++) {
     for (uint j=0; j<ll.data.size(); j++) {
       q(j)=fRand(ll(j), ul(j));
+      q_delta(j)=getDeltaWithLimits(q(j), 0.2, ll(j), ul(j));
     }
     JointList.push_back(q);
+    JointDeltaSeed.push_back(q_delta);
   }
 
   boost::posix_time::ptime start_time;
@@ -175,7 +197,9 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
     fk_solver.JntToCart(JointList[i],end_effector_pose);
     double elapsed = 0;
     // set seed
-    if (i == 0 || !randomPositionSeed)
+    if (closePositionSeed)
+      result = JointDeltaSeed[i];
+    else if (i == 0 || !randomPositionSeed)
       result = nominal;
     else
       result = JointList[i-1];
@@ -207,11 +231,14 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
   for (uint i=0; i < num_samples_pos; i++) {
     fk_solver.JntToCart(JointList[i],end_effector_pose);
     double elapsed = 0;
+    if (closePositionSeed)
+      q = JointDeltaSeed[i];
+    else if (i == 0 || !randomPositionSeed)
+      q = nominal;
+    else // "random" seed
+      q = JointList[i-1];
     start_time = boost::posix_time::microsec_clock::local_time();
-    if (i == 0 || !randomPositionSeed)
-      rc=tracik_solver.CartToJnt(nominal,end_effector_pose,result);
-    else
-      rc=tracik_solver.CartToJnt(JointList[i-1],end_effector_pose,result);
+    rc=tracik_solver.CartToJnt(q,end_effector_pose,result);
     diff = boost::posix_time::microsec_clock::local_time() - start_time;
     elapsed = diff.total_nanoseconds() / 1e9;
     total_time+=elapsed;
@@ -282,11 +309,14 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
     for (uint i=0; i < num_samples_pos; i++) {
       fk_solver.JntToCart(JointList[i],end_effector_pose);
       double elapsed = 0;
+      if (closePositionSeed)
+        q = JointDeltaSeed[i];
+      else if (i == 0 || !randomPositionSeed)
+        q = nominal;
+      else // "random" seed
+        q = JointList[i-1];
       start_time = boost::posix_time::microsec_clock::local_time();
-      if (i == 0 || !randomPositionSeed)
-        rc=snsik_solver.CartToJnt(nominal,end_effector_pose,result);
-      else
-        rc=snsik_solver.CartToJnt(JointList[i-1],end_effector_pose,result);
+      rc=snsik_solver.CartToJnt(q,end_effector_pose,result);
       diff = boost::posix_time::microsec_clock::local_time() - start_time;
       elapsed = diff.total_nanoseconds() / 1e9;
       total_time+=elapsed;
@@ -429,12 +459,13 @@ int main(int argc, char** argv)
   std::string chain_start, chain_end, urdf_param;
   double timeout;
   bool randomPositionSeed;
-
+  bool closePositionSeed;
   nh.param("num_samples_pos", num_samples_pos, 100);
   nh.param("num_samples_vel", num_samples_vel, 1000);
   nh.param("chain_start", chain_start, std::string(""));
   nh.param("chain_end", chain_end, std::string(""));
   nh.param("random_position_seed", randomPositionSeed, false);
+  nh.param("close_position_seed", closePositionSeed, false);
 
   if (chain_start=="" || chain_end=="") {
     ROS_FATAL("Missing chain info in launch file");
@@ -447,7 +478,7 @@ int main(int argc, char** argv)
   if (num_samples_pos < 1)
     num_samples_pos = 1;
 
-  test(nh, num_samples_pos, num_samples_vel,  chain_start, chain_end, timeout, urdf_param, randomPositionSeed);
+  test(nh, num_samples_pos, num_samples_vel,  chain_start, chain_end, timeout, urdf_param, randomPositionSeed, closePositionSeed);
 
   // Useful when you make a script that loops over multiple launch files that test different robot chains
   std::vector<char *> commandVector;


### PR DESCRIPTION
Adds a seed that is close to the random joint
angle used in constructing an inverse kinematic solition.
This should simulate the most favorable (and realistic)
conditions for using the solver in cartesian movement.

TBD: - Parametrize the 0.2 radian delta for the seed
     - Test how close the resulting joint solutions are to the delta
       seed