### PR TITLE
First pass at adding nullspace bias tasks for the velocity and position solvers.

### DIFF
--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -344,7 +344,8 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
       vfk_solver.JntToCart(JointVelList[i],end_effector_vel);
       double elapsed = 0;
       start_time = boost::posix_time::microsec_clock::local_time();
-      rc=snsik_solver.CartToJnt(JointVelList[i].q, end_effector_vel.GetTwist(), result_vel);
+      rc=snsik_solver.CartToJnt(JointVelList[i].q, end_effector_vel.GetTwist(), nominal, result_vel);
+      //rc=snsik_solver.CartToJnt(JointVelList[i].q, end_effector_vel.GetTwist(), result_vel);
 
       diff = boost::posix_time::microsec_clock::local_time() - start_time;
       elapsed = diff.total_nanoseconds() / 1e9;

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -214,7 +214,7 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
     double elapsed = 0;
     result = JointSeed[i];
     start_time = boost::posix_time::microsec_clock::local_time();
-    int cnt = 0;
+    int cnt = 0;  // keep track of iteration count to enforce max number of iterations
     do {
       q=result; // when iterating start with last solution
       rc=kdl_solver.CartToJnt(q,end_effector_pose,result);
@@ -382,7 +382,7 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
       vfk_solver.JntToCart(JointVelList[i],end_effector_vel);
       double elapsed = 0;
       start_time = boost::posix_time::microsec_clock::local_time();
-      rc=snsik_solver.CartToJnt(JointVelList[i].q, end_effector_vel.GetTwist(), result_vel);
+      rc=snsik_solver.CartToJntVel(JointVelList[i].q, end_effector_vel.GetTwist(), result_vel);
 
       diff = boost::posix_time::microsec_clock::local_time() - start_time;
       elapsed = diff.total_nanoseconds() / 1e9;

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -180,12 +180,13 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
     else
       result = JointList[i-1];
     start_time = boost::posix_time::microsec_clock::local_time();
+    int cnt = 0;
     do {
       q=result; // when iterating start with last solution
       rc=kdl_solver.CartToJnt(q,end_effector_pose,result);
       diff = boost::posix_time::microsec_clock::local_time() - start_time;
       elapsed = diff.total_nanoseconds() / 1e9;
-    } while (rc < 0 && elapsed < timeout);
+    } while (rc < 0 && elapsed < timeout && cnt++ < 100);
     total_time+=elapsed;
     if (rc>=0)
       success++;

--- a/sns_ik_examples/src/ik_tests.cpp
+++ b/sns_ik_examples/src/ik_tests.cpp
@@ -285,7 +285,7 @@ void test(ros::NodeHandle& nh, double num_samples_pos, double num_samples_vel,
       double elapsed = 0;
       start_time = boost::posix_time::microsec_clock::local_time();
       if (i == 0 || !randomPositionSeed)
-        rc=snsik_solver.CartToJnt(nominal,end_effector_pose,result);
+        rc=snsik_solver.CartToJnt(nominal,end_effector_pose,nominal,result);
       else
         rc=snsik_solver.CartToJnt(JointList[i-1],end_effector_pose,result);
       diff = boost::posix_time::microsec_clock::local_time() - start_time;

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -86,7 +86,24 @@ namespace sns_ik {
     int CartToJnt(const KDL::JntArray &q_init,
                   const KDL::Frame &p_in,
                   KDL::JntArray &q_out,
-                  const KDL::Twist& bounds=KDL::Twist::Zero());
+                  const KDL::Twist& tolereances=KDL::Twist::Zero())
+    { return CartToJnt(q_init, p_in, KDL::JntArray(0), std::vector<std::string>(),
+                       q_out, tolereances);
+    }
+
+    int CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
+                  const KDL::JntArray& q_bias,
+                  KDL::JntArray &q_out,
+                  const KDL::Twist& tolerances=KDL::Twist::Zero())
+    { return CartToJnt(q_init, p_in, q_bias, m_jointNames,
+                       q_out, tolerances);
+    }
+
+    int CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
+                  const KDL::JntArray& q_bias,
+                  const std::vector<std::string>& biasNames,
+                  KDL::JntArray &q_out,
+                  const KDL::Twist& tolerances=KDL::Twist::Zero());
 
     int CartToJnt(const KDL::JntArray& q_in,
                   const KDL::Twist& v_in,
@@ -120,7 +137,12 @@ namespace sns_ik {
     std::shared_ptr<SNSVelocityIK> m_ik_vel_solver;
     std::shared_ptr<SNSPositionIK> m_ik_pos_solver;
     std::shared_ptr<KDL::ChainJntToJacSolver> m_jacobianSolver;
+
     void initialize();
+
+    bool nullspaceBiasTask(const KDL::JntArray& q_bias,
+                           const std::vector<std::string>& biasNames,
+                           MatrixD* jacobian, std::vector<int>* indicies);
 
   };
 }  //namespace

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -47,6 +47,7 @@ namespace sns_ik {
     SNS_IK(const KDL::Chain& chain,
            const KDL::JntArray& q_min, const KDL::JntArray& q_max,
            const KDL::JntArray& v_max, const KDL::JntArray& a_max,
+           const std::vector<std::string>& jointNames,
            double looprate=0.005, double eps=1e-5,
            sns_ik::VelocitySolveType type=sns_ik::SNS);
 
@@ -77,8 +78,32 @@ namespace sns_ik {
       return m_initialized;
     }
 
-    int CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in, KDL::JntArray &q_out, const KDL::Twist& bounds=KDL::Twist::Zero());
-    int CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in, KDL::JntArray& qdot_out);
+    inline bool getJointNames(std::vector<std::string> jointNames) {
+      jointNames = m_jointNames;
+      return m_initialized;
+    }
+
+    int CartToJnt(const KDL::JntArray &q_init,
+                  const KDL::Frame &p_in,
+                  KDL::JntArray &q_out,
+                  const KDL::Twist& bounds=KDL::Twist::Zero());
+
+    int CartToJnt(const KDL::JntArray& q_in,
+                  const KDL::Twist& v_in,
+                  KDL::JntArray& qdot_out)
+    { return CartToJnt(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(), qdot_out); }
+
+    int CartToJnt(const KDL::JntArray& q_in,
+                  const KDL::Twist& v_in,
+                  const KDL::JntArray& q_bias,
+                  KDL::JntArray& qdot_out)
+    { return CartToJnt(q_in, v_in, q_bias, m_jointNames, qdot_out); }
+
+    int CartToJnt(const KDL::JntArray& q_in,
+                  const KDL::Twist& v_in,
+                  const KDL::JntArray& q_bias,
+                  const std::vector<std::string>& biasNames,
+                  KDL::JntArray& qdot_out);
 
   private:
     bool m_initialized;
@@ -89,6 +114,8 @@ namespace sns_ik {
     KDL::JntArray m_lower_bounds, m_upper_bounds, m_velocity, m_acceleration;
     enum JointType { Revolute, Prismatic, Continuous };
     std::vector<JointType> m_types;
+    std::vector<std::string> m_jointNames;
+
     std::vector<KDL::JntArray> m_solutions;
     std::shared_ptr<SNSVelocityIK> m_ik_vel_solver;
     std::shared_ptr<SNSPositionIK> m_ik_pos_solver;

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -86,9 +86,9 @@ namespace sns_ik {
     int CartToJnt(const KDL::JntArray &q_init,
                   const KDL::Frame &p_in,
                   KDL::JntArray &q_out,
-                  const KDL::Twist& tolereances=KDL::Twist::Zero())
+                  const KDL::Twist& tolerances=KDL::Twist::Zero())
     { return CartToJnt(q_init, p_in, KDL::JntArray(0), std::vector<std::string>(),
-                       q_out, tolereances);
+                       q_out, tolerances);
     }
 
     // Assumes the NS bias is for all the joints in the correct order
@@ -106,23 +106,23 @@ namespace sns_ik {
                   KDL::JntArray &q_out,
                   const KDL::Twist& tolerances=KDL::Twist::Zero());
 
-    int CartToJnt(const KDL::JntArray& q_in,
-                  const KDL::Twist& v_in,
-                  KDL::JntArray& qdot_out)
-    { return CartToJnt(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(), qdot_out); }
+    int CartToJntVel(const KDL::JntArray& q_in,
+                    const KDL::Twist& v_in,
+                    KDL::JntArray& qdot_out)
+    { return CartToJntVel(q_in, v_in, KDL::JntArray(0), std::vector<std::string>(), qdot_out); }
 
     // Assumes the NS bias is for all the joints in the correct order
-    int CartToJnt(const KDL::JntArray& q_in,
-                  const KDL::Twist& v_in,
-                  const KDL::JntArray& q_bias,
-                  KDL::JntArray& qdot_out)
-    { return CartToJnt(q_in, v_in, q_bias, m_jointNames, qdot_out); }
+    int CartToJntVel(const KDL::JntArray& q_in,
+                    const KDL::Twist& v_in,
+                    const KDL::JntArray& q_bias,
+                    KDL::JntArray& qdot_out)
+    { return CartToJntVel(q_in, v_in, q_bias, m_jointNames, qdot_out); }
 
-    int CartToJnt(const KDL::JntArray& q_in,
-                  const KDL::Twist& v_in,
-                  const KDL::JntArray& q_bias,
-                  const std::vector<std::string>& biasNames,
-                  KDL::JntArray& qdot_out);
+    int CartToJntVel(const KDL::JntArray& q_in,
+                    const KDL::Twist& v_in,
+                    const KDL::JntArray& q_bias,
+                    const std::vector<std::string>& biasNames,
+                    KDL::JntArray& qdot_out);
 
   private:
     bool m_initialized;

--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -40,6 +40,16 @@ class SNSPositionIK {
     int CartToJnt(const KDL::JntArray& joint_seed,
                   const KDL::Frame& goal_pose,
                   KDL::JntArray* return_joints,
+                  const KDL::Twist& tolerances)
+    { return CartToJnt(joint_seed, goal_pose, KDL::JntArray(0), MatrixD(0,0),
+                       std::vector<int>(0), return_joints, tolerances); }
+
+    int CartToJnt(const KDL::JntArray& joint_seed,
+                  const KDL::Frame& goal_pose,
+                  const KDL::JntArray& joint_ns_bias,
+                  const MatrixD& ns_jacobian,
+                  const std::vector<int>& ns_indicies,
+                  KDL::JntArray* return_joints,
                   const KDL::Twist& tolerances);
 
     // TODO: looks like this would require the KDL solvers to be wrapped in smart pointers

--- a/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_velocity_ik.hpp
@@ -84,6 +84,7 @@ class SNSVelocityIK {
 
     VectorD getJointLimitLow() { return jointLimit_low; }
     VectorD getJointLimitHigh() { return jointLimit_high; }
+    VectorD getJointVelocityMax() { return maxJointVelocity; }
 
     void usePositionLimits(bool use) { m_usePositionLimits = use; }
 

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -90,6 +90,9 @@ Scalar FOSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
         scaleFactors[i_task] = 1.0;
         P = PS;
       }
+
+      // TESTING - Is this right?
+      P = P * P.transpose();
     }
   }
 

--- a/sns_ik_lib/src/fosns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fosns_velocity_ik.cpp
@@ -123,7 +123,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
   VectorD best_dq1;
   VectorD best_dq2;
   VectorD best_dqw;
-  int best_nSat;
+  //int best_nSat;
 
   MatrixD tildeZ;
   VectorD dq1, dq2;
@@ -202,7 +202,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
       best_dq1 = dq1;
       best_dq2 = dq2;
       best_dqw = dqw;
-      best_nSat = nSat[priority];
+      //best_nSat = nSat[priority];
     }
   }
 
@@ -537,7 +537,7 @@ Scalar FOSNSVelocityIK::SNSsingle(int priority,
         best_dq1 = dq1;
         best_dq2 = dq2;
         best_dqw = dqw;
-        best_nSat = nSat[priority];
+        //best_nSat = nSat[priority];
       }
       //check if the scaled solution is the optimum
       scaledMU = scalingFactor * lagrangeMu1 + lagrangeMup2w;

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -92,14 +92,13 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
   VectorD best_dq1;
   VectorD best_dq2;
   VectorD best_dqw;
-  int best_nSat;
+  //int best_nSat;
 
   MatrixD tildeZ;
   VectorD dq1, dq2, dqw;
 
   MatrixD bin, zin;
   Scalar dqw_in;
-  Scalar error;
 
   //initialization
   nSat[priority] = 0;
@@ -150,7 +149,7 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
     best_dq1 = dq1;
     best_dq2 = dq2;
     best_dqw = dqw;
-    best_nSat = 0;
+    //best_nSat = 0;
 
   }
 
@@ -239,7 +238,7 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
         best_dq1 = dq1;
         best_dq2 = dq2;
         best_dqw = dqw;
-        best_nSat = nSat[priority];
+        //best_nSat = nSat[priority];
       }
     }
 

--- a/sns_ik_lib/src/fsns_velocity_ik.cpp
+++ b/sns_ik_lib/src/fsns_velocity_ik.cpp
@@ -60,6 +60,9 @@ Scalar FSNSVelocityIK::getJointVelocity(VectorD *jointVelocity,
     
     if (scaleFactors[i_task] > 1)
           scaleFactors[i_task] = 1;
+
+    // TESTING - Is this right?
+    P = P * P.transpose();
   }
 
   // TODO: what is being returned here?
@@ -125,7 +128,7 @@ Scalar FSNSVelocityIK::SNSsingle(int priority,
 
   if (singularTask) {
     // the task is singular so return a scaled damped solution (no SNS possible)
-    ROS_ERROR("singular");
+    //ROS_ERROR("singular");
     if (scalingFactor >= 0.0) {
       nSat[priority] = 0;
       (*jointVelocity) = higherPriorityJointVelocity + scalingFactor * dq1 + dq2;

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -67,6 +67,7 @@ namespace sns_ik {
     m_upper_bounds.resize(m_chain.getNrOfJoints());
     m_velocity.resize(m_chain.getNrOfJoints());
     m_acceleration.resize(m_chain.getNrOfJoints());
+    m_jointNames.resize(m_chain.getNrOfJoints());
 
     unsigned int joint_num=0;
     for(std::size_t i = 0; i < chain_segments.size(); ++i) {
@@ -114,10 +115,10 @@ namespace sns_ik {
         m_upper_bounds(joint_num)=upper;
         m_velocity(joint_num) = velocity;
         m_acceleration(joint_num) = std::fabs(acceleration);
+        m_jointNames[joint_num] = joint->name;
 
-        ROS_INFO_STREAM("sns_ik Using joint "<<joint->name<<" lb:"
-                        <<m_lower_bounds(joint_num)<<" ub:"<<m_upper_bounds(joint_num)
-                        << " v:"<<m_velocity(joint_num)<<" a:"<<m_acceleration(joint_num));
+        ROS_INFO("sns_ik: Using joint %s lb: %.3f, ub: %.3f, v: %.3f, a: %.3f", joint->name.c_str(),
+                 m_lower_bounds(joint_num), m_upper_bounds(joint_num), m_velocity(joint_num), m_acceleration(joint_num));
         joint_num++;
       }
     }
@@ -127,8 +128,8 @@ namespace sns_ik {
 
   SNS_IK::SNS_IK(const KDL::Chain& chain, const KDL::JntArray& q_min,
                  const KDL::JntArray& q_max, const KDL::JntArray& v_max,
-                 const KDL::JntArray& a_max, double looprate, double eps,
-                 sns_ik::VelocitySolveType type):
+                 const KDL::JntArray& a_max, const std::vector<std::string>& jointNames,
+                 double looprate, double eps, sns_ik::VelocitySolveType type):
     m_initialized(false),
     m_looprate(looprate),
     m_eps(eps),
@@ -137,32 +138,36 @@ namespace sns_ik {
     m_lower_bounds(q_min),
     m_upper_bounds(q_max),
     m_velocity(v_max),
-    m_acceleration(a_max)
+    m_acceleration(a_max),
+    m_jointNames(jointNames)
   {
     initialize();
   }
 
   void SNS_IK::initialize() {
 
-    ROS_ASSERT_MSG(m_chain.getNrOfJoints()==m_lower_bounds.data.size(), \
+    ROS_ASSERT_MSG(m_chain.getNrOfJoints() == m_lower_bounds.rows(),
                 "SNS_IK: Number of joint lower bounds does not equal number of joints");
-    ROS_ASSERT_MSG(m_chain.getNrOfJoints()==m_upper_bounds.data.size(), \
+    ROS_ASSERT_MSG(m_chain.getNrOfJoints() == m_upper_bounds.rows(),
                 "SNS_IK: Number of joint upper bounds does not equal number of joints");
-    ROS_ASSERT_MSG(m_chain.getNrOfJoints()==m_velocity.data.size(), \
+    ROS_ASSERT_MSG(m_chain.getNrOfJoints() == m_velocity.rows(),
                 "SNS_IK: Number of max joint velocity bounds does not equal number of joints");
-    ROS_ASSERT_MSG(m_chain.getNrOfJoints()==m_acceleration.data.size(), \
+    ROS_ASSERT_MSG(m_chain.getNrOfJoints() == m_acceleration.rows(),
                 "SNS_IK: Number of max joint acceleration bounds does not equal number of joints");
+    ROS_ASSERT_MSG(m_chain.getNrOfJoints() == m_jointNames.size(),
+                    "SNS_IK: Number of joint names does not equal number of joints");
+
     // Populate a vector cooresponding to the type for every joint
-    for (std::size_t i=0; i<m_chain.segments.size(); i++) {
+    for (std::size_t i = 0; i < m_chain.segments.size(); i++) {
       std::string type = m_chain.segments[i].getJoint().getTypeName();
-      if (type.find("Rot")!=std::string::npos) {
-        if (m_upper_bounds(m_types.size())>=std::numeric_limits<float>::max() &&
-            m_lower_bounds(m_types.size())<=std::numeric_limits<float>::lowest()){
+      if (type.find("Rot") != std::string::npos) {
+        if (m_upper_bounds(m_types.size()) >= std::numeric_limits<float>::max() &&
+            m_lower_bounds(m_types.size()) <= std::numeric_limits<float>::lowest()){
           m_types.push_back(SNS_IK::JointType::Continuous);
         } else {
           m_types.push_back(SNS_IK::JointType::Revolute);
         }
-      } else if (type.find("Trans")!=std::string::npos) {
+      } else if (type.find("Trans") != std::string::npos) {
         m_types.push_back(SNS_IK::JointType::Prismatic);
       }
     }
@@ -213,7 +218,8 @@ bool SNS_IK::setVelocitySolveType(VelocitySolveType type) {
  return false;
 }
 
-int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in, KDL::JntArray &q_out, const KDL::Twist& tolerances) {
+int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
+                      KDL::JntArray &q_out, const KDL::Twist& tolerances) {
 
   if (!m_initialized) {
     ROS_ERROR("SNS_IK was not properly initialized with a valid chain or limits.");
@@ -222,12 +228,16 @@ int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in, KDL::
   return m_ik_pos_solver->CartToJnt(q_init, p_in, &q_out, tolerances);
 }
 
-int SNS_IK::CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in, KDL::JntArray& qdot_out) {
-
+int SNS_IK::CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in,
+                      const KDL::JntArray& q_bias,
+                      const std::vector<std::string>& biasNames,
+                      KDL::JntArray& qdot_out)
+{
   if (!m_initialized) {
     ROS_ERROR("SNS_IK was not properly initialized with a valid chain or limits.");
     return -1;
   }
+
   KDL::Jacobian jacobian;
   jacobian.resize(q_in.rows());
   if (m_jacobianSolver->JntToJac(q_in, jacobian) < 0)
@@ -235,6 +245,7 @@ int SNS_IK::CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in, KDL::Jn
     std::cout << "JntToJac failed" << std::endl;
     return -1;
   }
+
   StackOfTasks sot;
   Task task;
   task.jacobian = jacobian.data;
@@ -243,6 +254,32 @@ int SNS_IK::CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in, KDL::Jn
   for(size_t i = 0; i < 6; i++)
       task.desired(i) = v_in[i];
   sot.push_back(task);
+
+  // Calculate the nullspace goal as a configuration-space task.
+  // Creates a task Jacobian which maps the provided nullspace joints to
+  // the full joint state.
+  if (q_bias.rows()) {
+    ROS_ASSERT_MSG(q_bias.rows() == biasNames.size(), "SNS_IK: Number of joint bias and names differe");
+    Task task2;
+    task2.jacobian = MatrixD::Zero(q_in.rows(), q_bias.rows());
+    task2.desired = VectorD::Zero(q_bias.rows());
+    std::vector<std::string>::iterator it;
+    for (int ii = 0; ii < q_bias.rows(); ++ii) {
+      it = std::find(m_jointNames.begin(), m_jointNames.end(), biasNames[ii]);
+      if (it == m_jointNames.end())
+      {
+        std::cout << "Could not find bias joint name: " << biasNames[ii] << std::endl;
+        return -1;
+      }
+      int indx = std::distance(m_jointNames.begin(), it);
+      // This calculates a "nullspace velocity".
+      // There is an arbitrary scale factor which will be set by the max scale factor.
+      task2.desired(ii) = (q_bias(ii) - q_in(ii)) / m_looprate;
+      // TODO: may want to limit the NS velocity to 90% of max joint velocity
+      task2.jacobian(ii, indx) = 1;
+    }
+    sot.push_back(task2);
+  }
   return m_ik_vel_solver->getJointVelocity(&qdot_out.data, sot, q_in.data);
 }
 

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -30,8 +30,8 @@ namespace sns_ik {
                  const std::string& URDF_param, double looprate, double eps,
                  sns_ik::VelocitySolveType type) :
     m_initialized(false),
-    m_looprate(looprate),
     m_eps(eps),
+    m_looprate(looprate),
     m_solvetype(type)
   {
     ros::NodeHandle node_handle("~");
@@ -131,8 +131,8 @@ namespace sns_ik {
                  const KDL::JntArray& a_max, const std::vector<std::string>& jointNames,
                  double looprate, double eps, sns_ik::VelocitySolveType type):
     m_initialized(false),
-    m_looprate(looprate),
     m_eps(eps),
+    m_looprate(looprate),
     m_solvetype(type),
     m_chain(chain),
     m_lower_bounds(q_min),
@@ -280,7 +280,7 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
       return -1;
     }
     task2.desired = VectorD::Zero(q_bias.rows());
-    for (int ii = 0; ii < q_bias.rows(); ++ii) {
+    for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
       // This calculates a "nullspace velocity".
       // There is an arbitrary scale factor which will be set by the max scale factor.
       task2.desired(ii) = (q_bias(ii) - q_in(indicies[ii])) / m_looprate;
@@ -301,7 +301,7 @@ bool SNS_IK::nullspaceBiasTask(const KDL::JntArray& q_bias,
   *jacobian = MatrixD::Zero(m_jointNames.size(), q_bias.rows());
   indicies->resize(q_bias.rows(), 0);
   std::vector<std::string>::iterator it;
-  for (int ii = 0; ii < q_bias.rows(); ++ii) {
+  for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
     it = std::find(m_jointNames.begin(), m_jointNames.end(), biasNames[ii]);
     if (it == m_jointNames.end())
     {

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -242,10 +242,10 @@ int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
   }
 }
 
-int SNS_IK::CartToJnt(const KDL::JntArray& q_in, const KDL::Twist& v_in,
-                      const KDL::JntArray& q_bias,
-                      const std::vector<std::string>& biasNames,
-                      KDL::JntArray& qdot_out)
+int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
+                        const KDL::JntArray& q_bias,
+                        const std::vector<std::string>& biasNames,
+                        KDL::JntArray& qdot_out)
 {
   if (!m_initialized) {
     ROS_ERROR("SNS_IK was not properly initialized with a valid chain or limits.");

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -79,7 +79,7 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
   jacobian.resize(q_i.rows());
   KDL::Vector rotAxis, trans;
   KDL::Rotation rot;
-  double sf;
+  //double sf;
 
   int ii;
   for (ii = 0; ii < m_maxIterations; ++ii) {
@@ -132,7 +132,7 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
     sot[0].jacobian = jacobian.data;
 
     if (joint_ns_bias.rows()) {
-      for (int jj = 0; jj < joint_ns_bias.rows(); ++jj) {
+      for (size_t jj = 0; jj < joint_ns_bias.rows(); ++jj) {
         // This calculates a "nullspace velocity".
         // There is an arbitrary scale factor which will be set by the max scale factor.
         int indx = ns_indicies[jj];
@@ -144,7 +144,8 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
 
     }
 
-    sf = m_ikVelSolver->getJointVelocity(&qDot, sot, q_i.data);
+    //sf = m_ikVelSolver->getJointVelocity(&qDot, sot, q_i.data);
+    m_ikVelSolver->getJointVelocity(&qDot, sot, q_i.data);
 
     q_i.data += m_dt * qDot;
 

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -30,7 +30,7 @@ SNSPositionIK::SNSPositionIK(KDL::Chain chain, std::shared_ptr<SNSVelocityIK> ve
     m_jacobianSolver(chain),
     m_linearMaxStepSize(0.2),
     m_angularMaxStepSize(0.2),
-    m_maxIterations(150),
+    m_maxIterations(100),
     m_dt(0.2)
 {
 }
@@ -130,7 +130,7 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
     //std::cout << "    cart vel: " << sot[0].desired.transpose() << std::endl;
     //std::cout << "    qDot: " << qDot.transpose() << std::endl;
 
-    if (qDot.norm() < 1e-7) {  // TODO: config param
+    if (qDot.norm() < 1e-5) {  // TODO: config param
       //std::cout << "ERROR: Solution stuck, iter: "<<ii<<", error: " << lineErr << " m, " << rotErr << " rad" << std::endl;
       return -2;
     }

--- a/sns_ik_lib/src/sns_velocity_ik.cpp
+++ b/sns_ik_lib/src/sns_velocity_ik.cpp
@@ -256,12 +256,12 @@ Scalar SNSVelocityIK::SNSsingle(int priority,
       limit_excedeed = true;
       if (singularTask) {
         // the task is singular so return a scaled damped solution (no SNS possible)
-        ROS_WARN("task %d is singular, scaling factor: %f",priority,scalingFactor);
+        //ROS_WARN("task %d is singular, scaling factor: %f",priority,scalingFactor);
         if (scalingFactor >= 0.0) {
           (*jointVelocity) = tildeDotQ + JPinverse * (scalingFactor * task - jacobian * tildeDotQ);
         } else {
           // the task is not executed
-          ROS_INFO("task not executed: J sing");
+          //ROS_INFO("task not executed: J sing");
           //W[priority]=I;
           //dotQn=VectorD::Zero(n_dof);
           *jointVelocity = higherPriorityJointVelocity;


### PR DESCRIPTION
Added a secondary task to push the IK solutions toward a desired joint bias in the nullspace. 

This has not been fully optimized, but I am pushing this for further testing and integration with the rest of the system. The velocity solver saw a time increase of ~40% while the position solvers time increased 2-3x. The IK solvers should be able to recognize tasks in the joint configuration space to reduce unnecessary matrix math operations. The nullspace bias changes were not pushed into the testing framework.

I'm am open to suggestions for improvements to the interfaces.

