### PR TITLE
Added a different way for CMake to detect eigen3 deps

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -18,19 +18,19 @@ find_package(catkin REQUIRED
   COMPONENTS
   roscpp
   std_msgs
-  cmake_modules
   kdl_parser
 )
-find_package(Eigen REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(eigen3 REQUIRED eigen3)
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS Eigen orocos_kdl
+  DEPENDS eigen3 orocos_kdl
   CATKIN_DEPENDS roscpp std_msgs
   LIBRARIES sns_ik
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${eigen3_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
@@ -42,5 +42,5 @@ add_library(sns_ik src/sns_ik.cpp
             src/osns_sm_velocity_ik.cpp
             src/fsns_velocity_ik.cpp
             src/fosns_velocity_ik.cpp)
-target_link_libraries(sns_ik ${catkin_LIBRARIES} ${Eigen_LIBRARIES} ${orocos_kdl_LIBRARIES})
+target_link_libraries(sns_ik ${catkin_LIBRARIES} ${eigen3_INCLUDE_DIRS} ${orocos_kdl_LIBRARIES})
 install(TARGETS sns_ik LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/sns_ik_lib/package.xml
+++ b/sns_ik_lib/package.xml
@@ -30,7 +30,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>cmake_modules</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>orocos_kdl</build_depend>
 


### PR DESCRIPTION
Since we don't want to depend on `cmake_modules` internally, I created a workaround that uses pure `CMake` macros to find `eigen3`. That way both this repo and the internal one remain in sync.