### PR TITLE
Adds correct install directory and const parameters

### DIFF
--- a/sns_ik_lib/CMakeLists.txt
+++ b/sns_ik_lib/CMakeLists.txt
@@ -31,7 +31,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
-install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(DIRECTORY include/sns_ik/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 add_library(sns_ik src/sns_ik.cpp
             src/sns_ik_math_utils.cpp

--- a/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik_math_utils.hpp
@@ -55,16 +55,16 @@ namespace sns_ik {
    *  (\em double if \b _USE_DOUBLE_ is defined)
    */
   typedef double Scalar;
-  #define EPS 1e-6
-  #define LAMBDA_MAX 1e-6 //0.3
-  #define EPSQ 1e-10
+  const double EPS = 1e-6;
+  const double LAMBDA_MAX = 1e-6; //0.3
+  const double EPSQ = 1e-10;
 #else
   typedef Eigen::Matrix<float,Dynamic,Dynamic> MatrixD;
   typedef Eigen::Matrix<float,Dynamic,1> VectorD;
   typedef float Scalar;
-  #define EPS 1e-6
-  #define LAMBDA_MAX 0.3
-  #define EPSQ 1e-15
+  const float EPS = 1e-6;
+  const float LAMBDA_MAX = 0.3;
+  const float EPSQ = 1e-15;
 #endif
 
 #define INF 1e20;  // Should this be the std INF?


### PR DESCRIPTION
This commit fixes some build issues when attempting to build with stricter build flags by doing the following: 
- fixes the `sns_ik` library install header directory
- converts some of our preprocessor `#defines` to `const doubles` and `const floats`

