### PR TITLE
Nullpace bias gain and basic testing

### DIFF
--- a/sns_ik_examples/launch/test_ik_solvers.launch
+++ b/sns_ik_examples/launch/test_ik_solvers.launch
@@ -9,6 +9,8 @@
   <arg name="use_random_position_seed" default="false"/>
   <arg name="use_delta_position_seed" default="false"/>
   <arg name="delta_position_seed_value" default="0.2"/>
+  <arg name="nullspace_bias_task" default="false"/>
+  <arg name="nullspace_gain" default="0.3"/>
 
   <node name="sns_ik_tests" pkg="sns_ik_examples" type="all_ik_tests" output="screen">
     <param name="num_samples_pos" value="$(arg num_samples_pos)"/>
@@ -20,6 +22,8 @@
     <param name="use_random_position_seed" value="$(arg use_random_position_seed)"/>
     <param name="use_delta_position_seed" value="$(arg use_delta_position_seed)"/>
     <param name="delta_position_seed_value" value="$(arg delta_position_seed_value)"/>
+    <param name="nullspace_bias_task" value="$(arg nullspace_bias_task)"/>
+    <param name="nullspace_gain" value="$(arg nullspace_gain)"/>
   </node>
 
 </launch>

--- a/sns_ik_lib/include/sns_ik/sns_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_ik.hpp
@@ -124,10 +124,16 @@ namespace sns_ik {
                     const std::vector<std::string>& biasNames,
                     KDL::JntArray& qdot_out);
 
+    // Nullspace gain should be specified between 0 and 1.0
+    double getNullspaceGain() { return m_nullspaceGain; }
+    void setNullspaceGain(double gain)
+    { m_nullspaceGain = std::max(std::min(gain, 1.0), 0.0); }
+
   private:
     bool m_initialized;
     double m_eps;
     double m_looprate;
+    double m_nullspaceGain;
     VelocitySolveType m_solvetype;
     KDL::Chain m_chain;
     KDL::JntArray m_lower_bounds, m_upper_bounds, m_velocity, m_acceleration;

--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -42,13 +42,14 @@ class SNSPositionIK {
                   KDL::JntArray* return_joints,
                   const KDL::Twist& tolerances)
     { return CartToJnt(joint_seed, goal_pose, KDL::JntArray(0), MatrixD(0,0),
-                       std::vector<int>(0), return_joints, tolerances); }
+                       std::vector<int>(0), 0.0, return_joints, tolerances); }
 
     int CartToJnt(const KDL::JntArray& joint_seed,
                   const KDL::Frame& goal_pose,
                   const KDL::JntArray& joint_ns_bias,
                   const MatrixD& ns_jacobian,
                   const std::vector<int>& ns_indicies,
+                  const double ns_gain,
                   KDL::JntArray* return_joints,
                   const KDL::Twist& tolerances);
 

--- a/sns_ik_lib/src/sns_ik.cpp
+++ b/sns_ik_lib/src/sns_ik.cpp
@@ -32,6 +32,7 @@ namespace sns_ik {
     m_initialized(false),
     m_eps(eps),
     m_looprate(looprate),
+    m_nullspaceGain(1.0),
     m_solvetype(type)
   {
     ros::NodeHandle node_handle("~");
@@ -133,6 +134,7 @@ namespace sns_ik {
     m_initialized(false),
     m_eps(eps),
     m_looprate(looprate),
+    m_nullspaceGain(1.0),
     m_solvetype(type),
     m_chain(chain),
     m_lower_bounds(q_min),
@@ -236,7 +238,7 @@ int SNS_IK::CartToJnt(const KDL::JntArray &q_init, const KDL::Frame &p_in,
       return -1;
     }
     return m_ik_pos_solver->CartToJnt(q_init, p_in, q_bias, ns_jacobian, indicies,
-                                      &q_out, tolerances);
+                                      m_nullspaceGain, &q_out, tolerances);
   } else {
     return m_ik_pos_solver->CartToJnt(q_init, p_in, &q_out, tolerances);
   }
@@ -283,7 +285,7 @@ int SNS_IK::CartToJntVel(const KDL::JntArray& q_in, const KDL::Twist& v_in,
     for (size_t ii = 0; ii < q_bias.rows(); ++ii) {
       // This calculates a "nullspace velocity".
       // There is an arbitrary scale factor which will be set by the max scale factor.
-      task2.desired(ii) = (q_bias(ii) - q_in(indicies[ii])) / m_looprate;
+      task2.desired(ii) = m_nullspaceGain * (q_bias(ii) - q_in(indicies[ii])) / m_looprate;
       // TODO: may want to limit the NS velocity to 70-90% of max joint velocity
     }
     sot.push_back(task2);

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -44,6 +44,7 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
                              const KDL::JntArray& joint_ns_bias,
                              const MatrixD& ns_jacobian,
                              const std::vector<int>& ns_indicies,
+                             const double ns_gain,
                              KDL::JntArray* return_joints,
                              const KDL::Twist& tolerances)
 {
@@ -136,7 +137,7 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
         // This calculates a "nullspace velocity".
         // There is an arbitrary scale factor which will be set by the max scale factor.
         int indx = ns_indicies[jj];
-        double vel = 0.1 * (joint_ns_bias(jj) - q_i(indx)) / m_dt; // TODO: step size needs to be optimized
+        double vel = ns_gain * (joint_ns_bias(jj) - q_i(indx)) / m_dt; // TODO: step size needs to be optimized
         // TODO: may want to limit the NS velocity to 50% of max joint velocity
         //vel = std::max(-0.5*maxJointVel(indx), std::min(0.5*maxJointVel(indx), vel));
         sot[1].desired(jj) = vel;


### PR DESCRIPTION
Added the ability to set the nullspace bias gain in the position and velocity solvers. 

Also added basic testing of the nullspace bias task. Ian will expand on this to quantify the amount that the secondary task is affecting the solutions. 

The secondary task is roughly doubling the SNS solver time because it has doubled the number of matrix inversions needed. By recognizing that the secondary task was in the joint configuration space, some speed improvement could be achieved, that that is future optimization work.