### PR TITLE
Decaying barrier function to handle joint limits

### DIFF
--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -84,6 +84,17 @@ class SNSPositionIK {
     double m_angularMaxStepSize;
     double m_maxIterations;
     double m_dt;
+    bool m_useBarrierFunction;
+    double m_barrierInitAlpha;
+    double m_barrierDecay;
+
+    bool calcPositionAndError(const KDL::JntArray& q,
+                              const KDL::Frame& goal,
+                              KDL::Frame* pose,
+                              double* errL,
+                              double* errR,
+                              KDL::Vector* trans,
+                              KDL::Vector* rotAxis);
 };
 
 }  // namespace sns_ikl

--- a/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
+++ b/sns_ik_lib/include/sns_ik/sns_position_ik.hpp
@@ -75,6 +75,21 @@ class SNSPositionIK {
       m_dt = dt;
     }
 
+    void setUseBarrierFunction(bool use) {
+      m_useBarrierFunction = use;
+    }
+    void setBarrierInitAlpha(double alpha) {
+      m_barrierInitAlpha = alpha;
+    }
+    bool setBarrierDecay(double decay) {
+      if (decay > 0 && decay <= 1.0) {
+        m_barrierDecay = decay;
+        return true;
+      } else {
+        return false;
+      }
+    }
+
   private:
     KDL::Chain m_chain;
     std::shared_ptr<SNSVelocityIK> m_ikVelSolver;

--- a/sns_ik_lib/src/sns_position_ik.cpp
+++ b/sns_ik_lib/src/sns_position_ik.cpp
@@ -174,9 +174,11 @@ int SNSPositionIK::CartToJnt(const KDL::JntArray& joint_seed,
     // Apply a decaying barrier function
     // u = upper limit;  l = lower limit
     // theta(x) = -log(u - x) - log(-l + x)
-    // -alpha * dTheta(x)/dx = alpha*(1/(x-l) + 1/(x-u))
+    // -alpha * dTheta(x)/dx === alpha * (1/(x-l) + 1/(x-u))
     if (m_useBarrierFunction && (lineErr > 0.5 || rotErr > 0.5) ) {
       for (int j = 0; j < jl_low.rows(); ++j) {
+        // First force the joint within limits.
+        // It can not be exactly at the limit since it will cause a division by zero NaN in the barrier function.
         q_i.data[j] = std::max(std::min(q_i.data[j], jl_high[j] - 1e-7), jl_low[j] + 1e-7);
         q_i.data[j] += barrierAlpha * (1/(q_i.data[j] - jl_low[j]) + 1/(q_i.data[j] - jl_high[j]));
       }


### PR DESCRIPTION
Applies a decaying logarithmic barrier function to enforce joint limits. At each time step the constant coefficient, alpha, decreases to reduce the push away from joint limits.

    Logarithmic barrier function for both upper and and lower joint limits
    // u = upper limit;  l = lower limit
    // theta(x) = -log(u - x) - log(-l + x)
    Negative barrier function derivative
    // -alpha * dTheta(x)/dx = alpha*(1/(x-l) + 1/(x-u))

For random seeds, the success rate improved from ~50% to ~75%.

